### PR TITLE
Check nina-fw version in code

### DIFF
--- a/adafruit_aws_iot.py
+++ b/adafruit_aws_iot.py
@@ -66,9 +66,6 @@ class MQTT_CLIENT:
         else:
             raise TypeError("This class requires a preconfigured MiniMQTT object, \
                                 please create one.")
-        # Verify nina-fw => 1.4.0
-        fw_semver_maj = bytes(self.client.wifi.esp.firmware_version).decode("utf-8")[2]
-        assert int(fw_semver_maj) >= 4, "Please update nina-fw to 1.4.0 or above."
         # Verify MiniMQTT client object configuration
         try:
             self.cid = self.client.client_id
@@ -78,9 +75,6 @@ class MQTT_CLIENT:
                                 as the Client ID.")
         # Shadow-interaction topic
         self.shadow_topic = "$aws/things/{}/shadow".format(self.cid)
-        # Ensure set_certificate and set_private_key were run from ESP32SPI
-        assert self.client.wifi.esp.set_psk and self.client.wifi.esp.set_crt, "Certificate \
-            and private key must be set to your AWS Device Cert and Private Key."
         # keep_alive timer must be between 30 <= keep alive interval <= 1200 seconds
         # https://docs.aws.amazon.com/general/latest/gr/aws_service_limits.html
         assert 30 <= keep_alive <= 1200, "Keep_Alive timer \

--- a/examples/aws_iot_shadows.py
+++ b/examples/aws_iot_shadows.py
@@ -46,6 +46,10 @@ esp32_reset = DigitalInOut(board.ESP_RESET)
 
 spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
+
+# Verify nina-fw version >= 1.4.0
+assert int(bytes(esp.firmware_version).decode("utf-8")[2]) >= 4, "Please update nina-fw to >=1.4.0."
+
 """Use below for Most Boards"""
 status_light = neopixel.NeoPixel(board.NEOPIXEL, 1, brightness=0.2) # Uncomment for Most Boards
 """Uncomment below for ItsyBitsy M4"""

--- a/examples/aws_iot_shadows.py
+++ b/examples/aws_iot_shadows.py
@@ -50,9 +50,9 @@ esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
 # Verify nina-fw version >= 1.4.0
 assert int(bytes(esp.firmware_version).decode("utf-8")[2]) >= 4, "Please update nina-fw to >=1.4.0."
 
-"""Use below for Most Boards"""
+# Use below for Most Boards
 status_light = neopixel.NeoPixel(board.NEOPIXEL, 1, brightness=0.2) # Uncomment for Most Boards
-"""Uncomment below for ItsyBitsy M4"""
+# Uncomment below for ItsyBitsy M4
 # status_light = dotstar.DotStar(board.APA102_SCK, board.APA102_MOSI, 1, brightness=0.2)
 # Uncomment below for an externally defined RGB LED
 # import adafruit_rgbled

--- a/examples/aws_iot_simpletest.py
+++ b/examples/aws_iot_simpletest.py
@@ -46,6 +46,10 @@ esp32_reset = DigitalInOut(board.ESP_RESET)
 
 spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
+
+# Verify nina-fw version >= 1.4.0
+assert int(bytes(esp.firmware_version).decode("utf-8")[2]) >= 4, "Please update nina-fw to >=1.4.0."
+
 """Use below for Most Boards"""
 status_light = neopixel.NeoPixel(board.NEOPIXEL, 1, brightness=0.2) # Uncomment for Most Boards
 """Uncomment below for ItsyBitsy M4"""

--- a/examples/aws_iot_simpletest.py
+++ b/examples/aws_iot_simpletest.py
@@ -50,9 +50,9 @@ esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
 # Verify nina-fw version >= 1.4.0
 assert int(bytes(esp.firmware_version).decode("utf-8")[2]) >= 4, "Please update nina-fw to >=1.4.0."
 
-"""Use below for Most Boards"""
+# Use below for Most Boards
 status_light = neopixel.NeoPixel(board.NEOPIXEL, 1, brightness=0.2) # Uncomment for Most Boards
-"""Uncomment below for ItsyBitsy M4"""
+# Uncomment below for ItsyBitsy M4
 # status_light = dotstar.DotStar(board.APA102_SCK, board.APA102_MOSI, 1, brightness=0.2)
 # Uncomment below for an externally defined RGB LED
 # import adafruit_rgbled


### PR DESCRIPTION
This library requires nina-fw version 1.4.0 or above. Instead of checking the MiniMQTT's wifi client attribute, check the nina-fw version from within the code.

Notes:
* Remove nina-fw check within library, check version in code instead
* Remove `set_certificate` and `set_private_key` check within library, example code calls these two methods.