### PR TITLE
Update interface to match MQTT client

### DIFF
--- a/adafruit_aws_iot.py
+++ b/adafruit_aws_iot.py
@@ -227,6 +227,8 @@ class MQTT_CLIENT:
         Must be called within the keep_alive timeout specified to init.
         This method does not handle network connection/disconnection.
 
+        :param float timeout: client return after this timeout, in seconds.
+
         Example of "pumping" an AWS IoT message loop:
         ..code-block::python
 

--- a/adafruit_aws_iot.py
+++ b/adafruit_aws_iot.py
@@ -222,7 +222,7 @@ class MQTT_CLIENT:
             self.on_unsubscribe(self, user_data, topic, pid)
 
     # MiniMQTT Network Control Flow
-    def loop(self) -> None:
+    def loop(self, timeout: float = 0) -> None:
         """Starts a synchronous message loop which maintains connection with AWS IoT.
         Must be called within the keep_alive timeout specified to init.
         This method does not handle network connection/disconnection.
@@ -235,7 +235,7 @@ class MQTT_CLIENT:
 
         """
         if self.connected_to_aws:
-            self.client.loop()
+            self.client.loop(timeout)
 
     @staticmethod
     def validate_topic(topic: str) -> None:

--- a/adafruit_aws_iot.py
+++ b/adafruit_aws_iot.py
@@ -237,13 +237,6 @@ class MQTT_CLIENT:
         if self.connected_to_aws:
             self.client.loop()
 
-    def loop_forever(self) -> None:
-        """Begins a blocking, asynchronous message loop.
-        This method handles network connection/disconnection.
-        """
-        if self.connected_to_aws:
-            self.client.loop_forever()
-
     @staticmethod
     def validate_topic(topic: str) -> None:
         """Validates if user-provided pub/sub topics adhere to AWS Service Limits.

--- a/examples/aws_iot_native_networking.py
+++ b/examples/aws_iot_native_networking.py
@@ -118,6 +118,6 @@ aws_iot.connect()
 # NOTE: NO code below this loop will execute
 # NOTE: Network reconnection is NOT handled within this loop
 while True:
-    aws_iot.loop()
+    aws_iot.loop(10)
 
     time.sleep(1)

--- a/examples/aws_iot_native_networking.py
+++ b/examples/aws_iot_native_networking.py
@@ -17,7 +17,6 @@ from adafruit_aws_iot import MQTT_CLIENT
 # "device_cert_path" - Path to the Device Certificate from AWS IoT ("<THING_NAME>.cert.pem")
 # "device_key_path" - Path to the RSA Private Key from AWS IoT ("<THING_NAME>.private.key")
 # "broker" - The endpoint for the AWS IoT broker ("<PREFIX>.iot.<REGION>.amazonaws.com")
-# "port" - The port for the "broker" above (8883)
 # "client_id" - The client id. Your device's Policy needs to allow this client ("basicPubSub")
 #
 # pylint: disable=no-name-in-module,wrong-import-order
@@ -93,9 +92,8 @@ ssl_context.load_cert_chain(
 # Set up a MiniMQTT Client
 mqtt_client = MQTT.MQTT(
     broker=secrets["broker"],
-    port=secrets["port"],
-    is_ssl=True,  # ssl is required
     client_id=secrets["client_id"],
+    is_ssl=True,
     socket_pool=pool,
     ssl_context=ssl_context,
 )

--- a/examples/aws_iot_shadows.py
+++ b/examples/aws_iot_shadows.py
@@ -163,14 +163,14 @@ aws_iot.connect()
 # Pump the message loop forever, all events
 # are handled in their callback handlers
 # while True:
-#   aws_iot.loop()
+#   aws_iot.loop(10)
 
 # Start a blocking message loop...
 # NOTE: NO code below this loop will execute
 # NOTE: Network reconnection is handled within this loop
 while True:
     try:
-        aws_iot.loop()
+        aws_iot.loop(10)
     except (ValueError, RuntimeError) as e:
         print("Failed to get data, retrying\n", e)
         wifi.reset()

--- a/examples/aws_iot_shadows.py
+++ b/examples/aws_iot_shadows.py
@@ -141,6 +141,7 @@ ssl_context = adafruit_connection_manager.get_radio_ssl_context(esp)
 client = MQTT.MQTT(
     broker=secrets["broker"],
     client_id=secrets["client_id"],
+    is_ssl=True,
     socket_pool=pool,
     ssl_context=ssl_context,
 )

--- a/examples/aws_iot_simpletest.py
+++ b/examples/aws_iot_simpletest.py
@@ -160,14 +160,14 @@ aws_iot.connect()
 # Pump the message loop forever, all events
 # are handled in their callback handlers
 # while True:
-#   aws_iot.loop()
+#   aws_iot.loop(10)
 
 # Start a blocking message loop...
 # NOTE: NO code below this loop will execute
 # NOTE: Network reconnection is handled within this loop
 while True:
     try:
-        aws_iot.loop()
+        aws_iot.loop(10)
     except (ValueError, RuntimeError) as e:
         print("Failed to get data, retrying\n", e)
         wifi.reset()

--- a/examples/aws_iot_simpletest.py
+++ b/examples/aws_iot_simpletest.py
@@ -138,6 +138,7 @@ ssl_context = adafruit_connection_manager.get_radio_ssl_context(esp)
 client = MQTT.MQTT(
     broker=secrets["broker"],
     client_id=secrets["client_id"],
+    is_ssl=True,
     socket_pool=pool,
     ssl_context=ssl_context,
 )


### PR DESCRIPTION
Removed a method which calls a non-existent MQTT function. Adds `is_ssl=True` to two of the example files - it isn't possible to connect to AWS IoT directly without TLS/SSL enabled. Updated 'loop()' with same interface as client method. 